### PR TITLE
fix(health): update to upstream changes

### DIFF
--- a/lua/telescope/_extensions/software-licenses/health.lua
+++ b/lua/telescope/_extensions/software-licenses/health.lua
@@ -1,4 +1,4 @@
-local health = require("health")
+local health = vim.health or require("health")
 local M = {}
 
 local vim_installed = function()


### PR DESCRIPTION
The removal of health.lua in v9.0 causes errors when calling extensions.
Use the calls used in nvim-treesitter.